### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/components/ui/lazy-image.tsx
+++ b/src/components/ui/lazy-image.tsx
@@ -63,7 +63,14 @@ export const LazyImage = ({
 
   // Generate responsive src set for better performance
   const generateSrcSet = (baseSrc: string) => {
-    if (!baseSrc.includes('unsplash.com') && !baseSrc.includes('lovable-uploads')) {
+    try {
+      const parsedUrl = new URL(baseSrc);
+      const allowedHosts = ['unsplash.com', 'lovable-uploads'];
+      if (!allowedHosts.includes(parsedUrl.host)) {
+        return undefined;
+      }
+    } catch (error) {
+      // If URL parsing fails, treat it as invalid
       return undefined;
     }
     


### PR DESCRIPTION
Potential fix for [https://github.com/skinyanjui/sam-junk-clean/security/code-scanning/1](https://github.com/skinyanjui/sam-junk-clean/security/code-scanning/1)

To fix the issue, the code should parse the `baseSrc` URL and validate its host explicitly. This ensures that the host matches the expected domain (`unsplash.com`) or other allowed domains. The `URL` constructor in JavaScript can be used to parse the URL and extract its host for comparison.

Steps to implement the fix:
1. Replace the substring check (`baseSrc.includes('unsplash.com')`) with a host validation using the `URL` constructor.
2. Define a whitelist of allowed hosts (e.g., `unsplash.com` and `lovable-uploads`).
3. Check if the parsed host matches one of the allowed hosts.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
